### PR TITLE
Set DISPLAY variable different for macos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,7 +84,8 @@ Vagrant.configure("2") do |config|
     ansible.verbose = "v"
     ansible.playbook = "provisioning/setup_machine.yml"
     ansible.extra_vars = {
-      el_version: "#{el_version}"
+      el_version: "#{el_version}",
+      is_macos: if (/darwin/ =~ RUBY_PLATFORM) != nil; true else false end,
     }
   end
 end

--- a/provisioning/group_vars/all.yml
+++ b/provisioning/group_vars/all.yml
@@ -1,3 +1,4 @@
 ---
 nifi_version: "{{ lookup('env', 'NIFI_VERSION') | default('1.21.0', True) }}"
 mariadb_client_version: "{{ lookup('env', 'MARIADB_CLIENT_VERSION') | default('3.1.4', True) }}"
+is_macos: "{{ lookup('env', 'IS_MACOS') | default(false, True) | bool }}"

--- a/provisioning/roles/environment/tasks/main.yml
+++ b/provisioning/roles/environment/tasks/main.yml
@@ -298,12 +298,21 @@
   shell: "{{ home_dir }}/moretools.sh"
   become: true
 
-- name: Set DISPLAY value for x-server
+- name: Set DISPLAY value for x-server - windows/linux
   lineinfile:
     path: "{{ home_dir }}/.bashrc"
     insertafter: EOF
     line: 'export DISPLAY="10.0.2.2:0.0"'
     state: present
+  when: not is_macos
+
+- name: Set DISPLAY value for x-server - macos
+  lineinfile:
+    path: "{{ home_dir }}/.bashrc"
+    insertafter: EOF
+    line: 'export DISPLAY="localhost:10.0"'
+    state: present
+  when: is_macos
 
 - name: Source .bashrc file
   shell: "source {{ home_dir }}/.bashrc"


### PR DESCRIPTION
Set DISPLAY varaible different for macos

- When macos is being used it needs the DISPLAY variable to be "localhost:10.0". Otherwise (windows/linux) shall still set the variable to "10.0.2.2:0.0".