### PR TITLE
Add support for offline deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 - create a vagrant user with sudo priveleges
 - install ansible
 - login as vagrant
-- git clone the repo https://github.com/rthomas320/FAF-Project to /home/vagrant
-- cd /home/vagrant
-- edit /home/vagrant/provisioning/setup_machine.yml change - hosts: all to - hosts: localhost
-- anisble-playbook provisioning/setup_machine.yml
-- source /home/vagrant/.bashrc [to set DISPLAY variable of VM to local machine for firefox to display]
+- `git clone https://github.com/ctc-oss/noe-setup` to /home/vagrant
+- `cd /home/vagrant`
+- edit `/home/vagrant/provisioning/setup_machine.yml` change `- hosts: all` to `- hosts: localhost`
+- `ansible-playbook provisioning/setup_machine.yml`
+- `source /home/vagrant/.bashrc` [to set DISPLAY variable of VM to local machine for firefox to display]
 - follow the instructions below
 Note: The custom nifi_processors source files will be in /home/vagrant/nifi_processors instead
- of /home/vagrant/source/nifi_processors as in the OVA.
+ of `/home/vagrant/source/nifi_processors` as in the OVA.
  The custom nifi processors use sftp to pass and retrieve files. The processor is configured to
  sftp to the localhost with 'root' as the user and 'vagrant' as the password.  The configuration
  for the Saniitzer1, Sanitizer2, Sanitizer3, and Analyzer1 processors may be changed to use
@@ -21,60 +21,60 @@ Note: The custom nifi_processors source files will be in /home/vagrant/nifi_proc
 
 To build custom NiFi processors and install the newly built nar file
 
-- cd /home/vagrant/source/nifi_processors
-- run: mvn clean install -Dmaven.test.skip=true
-- sudo cp /home/vagrant/source/nifi_processors/target/siaft-processors.nar /opt/nifi-latest/lib/
-- sudo chown nifi.nifi /opt/nifi-latest/lib/siaft-processors.nar
-- sudo systemctl restart nifi
+- `cd /home/vagrant/source/nifi_processors`
+- run: `mvn clean install -Dmaven.test.skip=true`
+- `sudo cp /home/vagrant/source/nifi_processors/target/siaft-processors.nar /opt/nifi-latest/lib/`
+- `sudo chown nifi.nifi /opt/nifi-latest/lib/siaft-processors.nar`
+- `sudo systemctl restart nifi`
 
 ---
 
 ## To test the NiFi flow with the new or existing custom NiFi processors nar file
 
-- vim /etc/ssh/sshd_config
+- `vim /etc/ssh/sshd_config`
 - change PasswordAuthentication no to PasswordAuthentication yes
-- systemctl restart sshd
-- sudo passwd root
-- su root
-- cd /home/nifi
-- ./setup-nifi-mock-env.sh
-- cp /home/nifi/data/hold/\* /home/nifi/data/in/
+- `systemctl restart sshd`
+- `sudo passwd root`
+- `su root`
+- `cd /home/nifi`
+- `./setup-nifi-mock-env.sh`
+- `cp /home/nifi/data/hold/\* /home/nifi/data/in/`
 - open a new terminal window
 - log in as vagrant
 - start firefox
 - open browser window to https://localhost:8443/nifi
-- cat /home/vagrant/nifi-creds.txt
+- `cat /home/vagrant/nifi-creds.txt`
 - login into NiFi with the credentials from cat results
 - save credentials in the popup screen
 - in the Operate Nifi Flow click the last icon to upload the template file
 - click select template
-- find the template file in the /home/vagrant/Downloads directory, highlight it, click open button
+- find the template file in the `/home/vagrant/Downloads` directory, highlight it, click open button
 - click the upload button
 - click OK to close the dialog box
 - click the and drag the template icon in the colored nifi menu to the nifi grid
 - click add to add the template that was uploaded
 - click a blank spot in the grid to un-highlight the processors and the relationships
 - right click a blank spot in the grid and choose enable all controller services in the popup menu
-- go back to the terminal window with root user in directory /home/nifi
-- ./start-nifi-mock-processors.sh
+- go back to the terminal window with root user in directory `/home/nifi`
+- `./start-nifi-mock-processors.sh`
 - return to nifi flow in the firefox browser
 - right click a blank area of the grid and select start from the popup menu
 - right click a blank area of the grid and select refresh
 - repeat refreshes until the three sample files are processed
   [Write Analyzer Results to The Database show 3 in and 3 out]
 - right click a blank area of the grid select stop
-- go to the terminal window with root user in directory /home/nifi
-- sudo ./stop-nifi-mock-processors.sh
-- exit [root]
-- mysql -u vagrant -pvagrant siaft [to enter database commandline prompt]
-- select \* from FileAttributes;
-- select \* from Sanitize;
-- select \* from Analysis;
-- quit [to exit DB commandline prompt]
-- sudo cat /home/nifi/data/out/some.txt to see s1, s2, s3 at the bottom of the file
+- go to the terminal window with root user in directory `/home/nifi`
+- `sudo ./stop-nifi-mock-processors.sh`
+- `exit` [root]
+- `mysql -u vagrant -pvagrant siaft [to enter database commandline prompt]`
+- `select \* from FileAttributes;`
+- `select \* from Sanitize;`
+- `select \* from Analysis;`
+- `quit` [to exit DB commandline prompt]
+- `sudo cat /home/nifi/data/out/some.txt` to see s1, s2, s3 at the bottom of the file
   [indicating the file went through sanitizer1, sanitizer2, and sanitizer3]
-- sudo cat /home/nifi/data/out/somemore.txt see s1, s2, s3 at the bottom of the file
-- sudo cat /home/nifi/data/out/evenmore.txt see s1, s2, s3 at the bottom of the file
+- `sudo cat /home/nifi/data/out/somemore.txt` see s1, s2, s3 at the bottom of the file
+- `sudo cat /home/nifi/data/out/evenmore.txt` see s1, s2, s3 at the bottom of the file
 
 ---
 
@@ -120,3 +120,47 @@ To build custom NiFi processors and install the newly built nar file
     ```bash
     vagrant up
     ```
+
+---
+## Offliine Support
+
+### Downloading Files
+
+To get all files needed for an offline deployment, the following software will need to installed on the local machine:
+
+- `ansible`
+- `docker`
+
+Once you have those installed, run:
+
+```bash
+ansible-playbook -v provisioning/offline_download.yml
+```
+
+This will download all the files needed to `provisioning/roles/offline-download/files/offline-files`. To move these over zip the folder and then extract in the SAME location on the offline machine. The other provisioning code will look inside of `provisioning/roles/offline-download/files/offline-files` when deploying offline so make sure the proper contents are there.
+
+### Deploying
+
+**NOTE**: This example is running the provisioning on a already made RHEL8/ROCKY8 or RHEL9/ROCKY9 machine. Since being offline, to be able to use `Vagrant` some additional steps would be needed that we are not going to look into at the moment.
+
+**Prereqs**:
+
+To deploy offline make sure:
+
+- Created a RHEL8/ROCKY8 or RHEL9/ROCKY9 VM with `ansible` installed.
+- The extracted content of the offline files are inside of `provisioning/roles/offline-download/files/offline-files`.
+- If wanting to use custom yum repos make sure to set the varaiable `OFFLINE_YUM_REPO_LOCATION`.
+  - When setting this variable append either `local:` or `remote:` to the beginning if providing a file path. This will help ensure if copying the file from one place to another that we know wheter its from the machine running the ansible or the machine being created.
+  - However, if this is a URL starting with `http` or `https` it will try downloading that file to the proper location.
+
+**Run provisioning**:
+
+- Update the `provisioning/setup_machine.yml` to set `- hosts: all` to `- hosts: localhost`.
+
+- Run:
+
+  ```bash
+  ansible-playbook \
+    --extra-vars is_offline=true \
+    provisioning/setup_machine.yml
+  ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,6 +94,7 @@ Vagrant.configure("2") do |config|
       el_version: "#{el_version}",
       is_macos: (/darwin/ =~ RUBY_PLATFORM) != nil ? true : false,
       copy_source: !use_synced_folder,
+      is_offline: ENV['IS_OFFLINE'].to_s.downcase == "true" ? true : false
     }
   end
 end

--- a/provisioning/group_vars/all.yml
+++ b/provisioning/group_vars/all.yml
@@ -2,3 +2,4 @@
 nifi_version: "{{ lookup('env', 'NIFI_VERSION') | default('1.21.0', True) }}"
 mariadb_client_version: "{{ lookup('env', 'MARIADB_CLIENT_VERSION') | default('3.1.4', True) }}"
 is_macos: "{{ lookup('env', 'IS_MACOS') | default(false, True) | bool }}"
+is_offline: "{{ lookup('env', 'IS_OFFLINE') | default(false, True) | bool }}"

--- a/provisioning/offline_download.yml
+++ b/provisioning/offline_download.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - offline-download

--- a/provisioning/roles/environment/defaults/main.yml
+++ b/provisioning/roles/environment/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+nifi:
+  url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.zip"
+  path: "{{ role_path }}/../offline-download/files/offline-files/nifi-{{ nifi_version }}-bin.zip"
+
+nifi_tools:
+  url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-toolkit-{{ nifi_version }}-bin.zip"
+  path: "{{ role_path }}/../offline-download/files/offline-files/nifi-toolkit-{{ nifi_version }}-bin.zip"
+
+maven_deps_path: "{{ role_path }}/../offline-download/files/offline-files/maven-deps.zip"
+
+offline_yum_repo_location: "{{ lookup('env', 'OFFLINE_YUM_REPO_LOCATION') | default('', True) }}"

--- a/provisioning/roles/environment/tasks/java.yml
+++ b/provisioning/roles/environment/tasks/java.yml
@@ -1,0 +1,35 @@
+---
+- name: Install Java 17
+  dnf:
+    name:
+      - java-17-openjdk
+      - java-17-openjdk-devel
+  become: true
+
+- name: Set Java Version
+  shell: sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-17.0.7.0.7-3.{{ el_version }}.{{ ansible_architecture }}/bin/java
+  become: true
+
+- name: Set Java Compiler Version
+  shell: sudo update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-17.0.7.0.7-3.{{ el_version }}.{{ ansible_architecture }}/bin/javac
+  become: true
+
+- name: Copy Java-home.sh 
+  copy:
+    src: "{{ role_path }}/files/java-home.sh"
+    dest: /etc/profile.d
+    mode: 0644
+    owner: root
+    group: root
+  become: true
+
+- name: Source Java Paths
+  shell: "source /etc/profile.d/java-home.sh"
+  become: true
+
+- name: Install Maven
+  dnf:
+    name:
+      - maven
+    state: latest
+  become: true

--- a/provisioning/roles/environment/tasks/main.yml
+++ b/provisioning/roles/environment/tasks/main.yml
@@ -1,289 +1,60 @@
 ---
+- name: Remove all repos to make sure they are not enabled - offline
+  shell: rm -rf /etc/yum.repos.d/*
+  become: true
+  when: is_offline and offline_yum_repo_location != ''
+
+- name: Download offline repo - offline
+  get_url:
+    url: "{{ offline_yum_repo_location }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    force: true # always download to make sure its enabled
+  become: true
+  when: >-
+    is_offline
+    and (
+      offline_yum_repo_location is regex('^https:.*')
+      or offline_yum_repo_location is regex('^http:.*')
+    )
+
+- name: Copy offline repo - offline
+  copy:
+    src: "{{ offline_yum_repo_location.replace('remote:', '').replace('local:', '') }}"
+    dest: /etc/yum.repos.d/
+    owner: root
+    group: root
+    remote_src: "{{ true if offline_yum_repo_location is regex('^remote:.*') else false | bool }}"
+    force: true # always copy to make sure its enabled
+  become: true
+  when: >-
+    is_offline
+    and (
+      offline_yum_repo_location is regex('^remote:.*')
+      or offline_yum_repo_location is regex('^local:.*')
+    )
+
+- name: DNF Update Cache
+  dnf:
+    update_cache: true
+    state: latest
+  become: true
+
 - name: DNF Update
   dnf:
     name: "*"
     state: latest
   become: true
 
-- name: DNF Update Cache
-  dnf:
-    update_cache: true
-    state: latest
+- name: Install packages
+  import_tasks: "./packages.yml"
 
-- name: YUM Update
-  yum:
-    name: "*"
-    state: latest
-  become: true
+- name: Configure Java
+  import_tasks: "./java.yml"
 
-- name: Install development tools
-  dnf:
-    name:
-      - libsecret-devel
-      - cmake
-      - make
-      - gcc-c++
-      - epel-release
-      - ruby
-      - hexedit
-      - xorg-x11-xauth
-      - mod_ssl
-      - httpd
-      - wget
-      - zip
-      - unzip
-    state: present
-  become: true
-
-# - name: Install Server with GUI, ensures VM has GUI
-#   dnf:
-#     name: "@Server with GUI"
-#     state: present
-#   become: true
-
-- name: Install Python & Pip
-  dnf:
-    name:
-      - python3
-      - python3-pip
-    state: latest
-  become: true
-
-- name: Install MESA Drivers
-  dnf:
-    name:
-      - mesa-dri-drivers
-  become: true
-
-- name: Install Java 17
-  dnf:
-    name:
-      - java-17-openjdk
-      - java-17-openjdk-devel
-  become: true
-
-- name: Set Java Version
-  shell: sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-17.0.7.0.7-3.{{ el_version }}.{{ ansible_architecture }}/bin/java
-  become: true
-
-- name: Set Java Compiler Version
-  shell: sudo update-alternatives --set javac /usr/lib/jvm/java-17-openjdk-17.0.7.0.7-3.{{ el_version }}.{{ ansible_architecture }}/bin/javac
-  become: true
-
-- name: Copy Java-home.sh 
-  copy:
-    src: "{{ role_path }}/files/java-home.sh"
-    dest: /etc/profile.d
-    mode: 0644
-    owner: root
-    group: root
-  become: true
-
-- name: Source Java Paths
-  shell: "source /etc/profile.d/java-home.sh"
-  become: true
-
-- name: Install Maven
-  dnf:
-    name:
-      - maven
-    state: latest
-  become: true
-
-- name: Add nifi group
-  become: true
-  group:
-    name: nifi
-    state: present
-
-- name: Add nifi user
-  become: true
-  user:
-    name: nifi
-    group: nifi
-    createhome: true
-
-- name: Create folder for latest version of NiFi
-  file:
-    path: /opt/nifi
-    state: directory
-    owner: nifi
-    group: nifi
-    mode: 0755
-  become: true
-
-- name: Download Version {{ nifi_version }} of NiFi
-  get_url:
-    url: https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.zip
-    dest: "{{ home_dir }}/nifi-{{ nifi_version }}-bin.zip"
-    mode: 0755
-
-- name: Unzip NiFi
-  shell: "unzip {{ home_dir }}/nifi-{{ nifi_version }}-bin.zip -d /opt/nifi"
-  become: true
-  args:
-    creates: /opt/nifi/nifi-{{ nifi_version }}
-
-- name: Download NiFi Tools
-  get_url:
-    url: https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-toolkit-{{ nifi_version }}-bin.zip
-    dest: "{{ home_dir }}/nifi-toolkit-{{ nifi_version }}-bin.zip"
-    mode: 0755
-
-- name: Unzip NiFi Tools
-  shell: "unzip {{ home_dir }}/nifi-toolkit-{{ nifi_version }}-bin.zip -d /opt/nifi"
-  become: true
-  args:
-    creates: /opt/nifi/nifi-toolkit-{{ nifi_version }}
-
-- name: Create Folder for NiFi
-  file:
-    path: /opt/nifi/
-    state: directory
-    owner: nifi
-    group: nifi
-    mode: 0755
-    recurse: true
-  become: true
-
-- name: Create symlink from installed version of NiFi
-  file:
-    src: /opt/nifi/nifi-{{ nifi_version }}/
-    path: /opt/nifi-latest
-    state: link
-    owner: nifi
-    group: nifi
-  become: true
-
-- name: Copy NiFi service to Vagrant machine
-  copy:
-    src: "{{ role_path }}/files/nifi.service"
-    dest: /etc/systemd/system/
-    mode: 0755
-    owner: root
-  become: true
-
-- name: Create vagrant Downloads directory
-  file:
-    path: "{{ home_dir }}/Downloads"
-    state: directory
-    mode: 0755
-    owner: vagrant
-    group: vagrant
-  become: true
-  
-- name: Copy NiFi Template to Vagrant Downloads
-  copy:
-    src: "{{ role_path }}/files/Nifi-NOE-Final-Template.xml"
-    dest: "{{ home_dir }}/Downloads"
-    mode: 0666
-    owner: vagrant
-  become: true
-
-- name: Stop NiFi if running
-  systemd:
-    name: nifi
-    state: stopped
-  become: true
-
-- name: Create NiFi data directory
-  file:
-    path: "{{ item  }}"
-    state: directory
-    mode: 0755
-    owner: nifi
-    group: nifi
-  with_items:
-    - /home/nifi/data/in
-    - /home/nifi/data/out
-    - /home/nifi/data/hold
-    - /home/nifi/data/error
-    - /home/nifi/data/reports
-  become: true
-
-- name: Copy initial test files to Nifi hold diretory
-  copy:
-    src: "{{ item }}"
-    dest: /home/nifi/data/hold
-    owner: nifi
-    group: nifi
-    mode: 0755
-  with_items:
-    - "{{ role_path }}/files/some.txt"
-    - "{{ role_path }}/files/somemore.txt"
-    - "{{ role_path }}/files/evenmore.txt"
-  become: true
-
-- name: Copy mock script files to Nifi home
-  copy:
-    src: "{{ item }}"
-    dest: /home/nifi/
-    owner: nifi
-    group: nifi
-    mode: 0755
-  with_items:
-    - "{{ role_path }}/files/analyzer1.sh"
-    - "{{ role_path }}/files/analyzer2.sh"
-    - "{{ role_path }}/files/analyzer2.sh"
-    - "{{ role_path }}/files/sanitizer1.sh"
-    - "{{ role_path }}/files/sanitizer2.sh"
-    - "{{ role_path }}/files/sanitizer3.sh"
-    - "{{ role_path }}/files/setup-nifi-mock_env.sh"
-    - "{{ role_path }}/files/start-nifi-mock-processors.sh"
-    - "{{ role_path }}/files/stop-nifi-mock-processors.sh"
-  become: true
-
-- name: Copy siaft-processors nar file to NiFi directory 
-  copy:
-    src: "{{ role_path }}/files/siaft-processors.nar"
-    dest: /opt/nifi/nifi-{{ nifi_version }}/lib/
-    mode: 0755
-    owner: nifi
-    group: nifi
-  become: true
-
-- name: Download Version {{ mariadb_client_version }} of mariadb client
-  get_url:
-    url: https://dlm.mariadb.com/2912798/Connectors/java/connector-java-{{ mariadb_client_version }}/mariadb-java-client-{{ mariadb_client_version }}.jar
-    dest: /opt/nifi/nifi-{{ nifi_version }}/lib/mariadb-java-client-{{ mariadb_client_version }}.jar
-    owner: nifi
-    group: nifi
-    mode: 0755
-  become: true
-
-- name: Enable NiFi Service and Start NiFi
-  systemd:
-    daemon-reload: true
-    name: nifi
-    state: started
-    enabled: true
-  become: true
-  
-- name: Install MESA graphics libraries
-  dnf:
-    name:
-      - mesa-libGL
-      - mesa-libEGL
-      - xorg-x11-server-common
-    state: latest
-  become: true
-
-- name: Install Firefox
-  yum:
-    name: firefox
-    state: latest
-  become: true
-
-- name: Set Timezone
-  timezone:
-    name: America/New_York
-  become: true
-
-- name: Install Git
-  dnf:
-    name: git
-    state: latest
-  become: true
+- name: Configure NiFi
+  import_tasks: "./nifi.yml"
 
 - name: Copy moretools Install Script
   copy:
@@ -317,26 +88,6 @@
 - name: Source .bashrc file
   shell: "source {{ home_dir }}/.bashrc"
 
-- name: Remove NiFi zip file
-  file:
-    path: "{{ home_dir }}/nifi-{{ nifi_version }}-bin.zip"
-    state: absent
-
-- name: Remove NiFi Toolkit zip file
-  file:
-    path: "{{ home_dir }}/nifi-toolkit-{{ nifi_version }}-bin.zip"
-    state: absent
-
-- name: Re-create empty NiFi file so not re-downloaded on provision failure
-  command: touch /home/vagrant/nifi-{{ nifi_version }}-bin.zip
-  args:
-    creates: /home/vagrant/nifi-{{ nifi_version }}-bin.zip
-
-- name: Re-create empty NiFi tool file so not re-downloaded on provision failure
-  command: touch /home/vagrant/nifi-toolkit-{{ nifi_version }}-bin.zip
-  args:
-    creates: /home/vagrant/nifi-toolkit-{{ nifi_version }}-bin.zip
-
 - name: Ensure {{ home_dir }}/source exists
   file:
     path: "{{ home_dir }}/source"
@@ -360,3 +111,11 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
   when: copy_source
+
+- name: Remove target from copied source if there
+  shell: "rm -rf {{ home_dir }}/source/nifi_processors/target || true"
+  when: copy_source
+
+- name: Install maven dependencies - offline
+  import_tasks: "./offline-maven.yml"
+  when: is_offline

--- a/provisioning/roles/environment/tasks/nifi.yml
+++ b/provisioning/roles/environment/tasks/nifi.yml
@@ -1,0 +1,178 @@
+---
+- name: Add nifi group
+  become: true
+  group:
+    name: nifi
+    state: present
+
+- name: Add nifi user
+  become: true
+  user:
+    name: nifi
+    group: nifi
+    createhome: true
+
+- name: Create folder for latest version of NiFi
+  file:
+    path: /opt/nifi
+    state: directory
+    owner: nifi
+    group: nifi
+    mode: 0755
+  become: true
+
+- name: Create Folder for NiFi
+  file:
+    path: /opt/nifi/
+    state: directory
+    owner: nifi
+    group: nifi
+    mode: 0755
+    recurse: true
+  become: true
+
+# If online, will download from the url then unzip
+- name: Unzip Version {{ nifi_version }} of NiFi
+  unarchive:
+    src: "{{ nifi.url if not is_offline else nifi.path }}"
+    dest: /opt/nifi
+    mode: 0755
+    remote_src: "{{ true if not is_offline else false | bool }}"
+    group: nifi
+    owner: nifi
+  become: true
+
+# If online, will download from the url then unzip
+- name: Unzip NiFi Tools
+  unarchive:
+    src: "{{ nifi_tools.url if not is_offline else nifi_tools.path }}"
+    dest: /opt/nifi
+    mode: 0755
+    remote_src: "{{ true if not is_offline else false | bool }}"
+    group: nifi
+    owner: nifi
+  become: true
+
+- name: Create symlink from installed version of NiFi
+  file:
+    src: /opt/nifi/nifi-{{ nifi_version }}/
+    path: /opt/nifi-latest
+    state: link
+    owner: nifi
+    group: nifi
+  become: true
+
+- name: Copy NiFi service to Vagrant machine
+  copy:
+    src: "{{ role_path }}/files/nifi.service"
+    dest: /etc/systemd/system/
+    mode: 0755
+    owner: root
+  become: true
+
+- name: Create vagrant Downloads directory
+  file:
+    path: "{{ home_dir }}/Downloads"
+    state: directory
+    mode: 0755
+    owner: vagrant
+    group: vagrant
+  become: true
+  
+- name: Copy NiFi Template to Vagrant Downloads
+  copy:
+    src: "{{ role_path }}/files/Nifi-NOE-Final-Template.xml"
+    dest: "{{ home_dir }}/Downloads"
+    mode: 0666
+    owner: vagrant
+  become: true
+
+- name: Stop NiFi if running
+  systemd:
+    name: nifi
+    state: stopped
+  become: true
+
+- name: Create NiFi data directory
+  file:
+    path: "{{ item  }}"
+    state: directory
+    mode: 0755
+    owner: nifi
+    group: nifi
+  with_items:
+    - /home/nifi/data/in
+    - /home/nifi/data/out
+    - /home/nifi/data/hold
+    - /home/nifi/data/error
+    - /home/nifi/data/reports
+  become: true
+
+- name: Copy initial test files to Nifi hold diretory
+  copy:
+    src: "{{ item }}"
+    dest: /home/nifi/data/hold
+    owner: nifi
+    group: nifi
+    mode: 0755
+  with_items:
+    - "{{ role_path }}/files/some.txt"
+    - "{{ role_path }}/files/somemore.txt"
+    - "{{ role_path }}/files/evenmore.txt"
+  become: true
+
+- name: Copy mock script files to Nifi home
+  copy:
+    src: "{{ item }}"
+    dest: /home/nifi/
+    owner: nifi
+    group: nifi
+    mode: 0755
+  with_items:
+    - "{{ role_path }}/files/analyzer1.sh"
+    - "{{ role_path }}/files/analyzer2.sh"
+    - "{{ role_path }}/files/analyzer2.sh"
+    - "{{ role_path }}/files/sanitizer1.sh"
+    - "{{ role_path }}/files/sanitizer2.sh"
+    - "{{ role_path }}/files/sanitizer3.sh"
+    - "{{ role_path }}/files/setup-nifi-mock_env.sh"
+    - "{{ role_path }}/files/start-nifi-mock-processors.sh"
+    - "{{ role_path }}/files/stop-nifi-mock-processors.sh"
+  become: true
+
+- name: Copy siaft-processors nar file to NiFi directory 
+  copy:
+    src: "{{ role_path }}/files/siaft-processors.nar"
+    dest: /opt/nifi/nifi-{{ nifi_version }}/lib/
+    mode: 0755
+    owner: nifi
+    group: nifi
+  become: true
+
+- name: Download Version {{ mariadb_client_version }} of mariadb client - online
+  get_url:
+    url: https://dlm.mariadb.com/2912798/Connectors/java/connector-java-{{ mariadb_client_version }}/mariadb-java-client-{{ mariadb_client_version }}.jar
+    dest: /opt/nifi/nifi-{{ nifi_version }}/lib/mariadb-java-client-{{ mariadb_client_version }}.jar
+    owner: nifi
+    group: nifi
+    mode: 0755
+  become: true
+  when: not is_offline
+
+- name: Copy Version {{ mariadb_client_version }} of mariadb client - offline
+  copy:
+    src: "{{ role_path }}/../offline-download/files/offline-files/mariadb-java-client-{{ mariadb_client_version }}.jar"
+    dest: "/opt/nifi/nifi-{{ nifi_version }}/lib/mariadb-java-client-{{ mariadb_client_version }}.jar"
+    owner: nifi
+    group: nifi
+    mode: 0755
+  become: true
+  when: is_offline
+
+- name: Enable NiFi Service and Start NiFi
+  systemd:
+    daemon-reload: true
+    name: nifi
+    state: started
+    enabled: true
+  become: true

--- a/provisioning/roles/environment/tasks/offline-maven.yml
+++ b/provisioning/roles/environment/tasks/offline-maven.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensure {{ home_dir }}/.m2/repository exists
+  file:
+    path: "{{ home_dir }}/.m2/repository"
+    state: directory
+    recurse: true
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+
+- name: Extract maven deps into {{ home_dir }}/.m2/repository
+  unarchive:
+    src: "{{ maven_deps_path }}"
+    dest: "{{ home_dir }}/.m2/repository"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"

--- a/provisioning/roles/environment/tasks/packages.yml
+++ b/provisioning/roles/environment/tasks/packages.yml
@@ -1,0 +1,66 @@
+---
+- name: Install development tools
+  dnf:
+    name:
+      - libsecret-devel
+      - cmake
+      - make
+      - gcc-c++
+      - epel-release
+      - ruby
+      - hexedit
+      - xorg-x11-xauth
+      - mod_ssl
+      - httpd
+      - wget
+      - zip
+      - unzip
+    state: present
+  become: true
+
+- name: Install Server with GUI, ensures VM has GUI - offline
+  dnf:
+    name: "@Server with GUI"
+    state: present
+  become: true
+  when: is_offline
+
+- name: Install Python & Pip
+  dnf:
+    name:
+      - python3
+      - python3-pip
+    state: latest
+  become: true
+
+- name: Install MESA Drivers
+  dnf:
+    name:
+      - mesa-dri-drivers
+  become: true
+
+- name: Install MESA graphics libraries
+  dnf:
+    name:
+      - mesa-libGL
+      - mesa-libEGL
+      - xorg-x11-server-common
+    state: latest
+  become: true
+
+- name: Install Firefox
+  yum:
+    name: firefox
+    state: latest
+  become: true
+
+- name: Set Timezone
+  timezone:
+    name: America/New_York
+  become: true
+
+- name: Install Git
+  dnf:
+    name: git
+    state: latest
+  become: true

--- a/provisioning/roles/offline-download/files/.gitignore
+++ b/provisioning/roles/offline-download/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/provisioning/roles/offline-download/tasks/main.yml
+++ b/provisioning/roles/offline-download/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+- name: Ensure offline-files directory exists
+  file:
+    path: "{{ role_path }}/files/offline-files"
+    state: directory
+
+# Using docker is better because then the dependencies downloaded are using a matching OS (RHEL/ROCKY 8/9).
+# Use clean install instead of "dependency:go-offline" as "dependency:go-offline" doesn't get everything.
+- name: Download maven dependencies using docker
+  docker_container:
+    name: noe_setup_maven_deps_download
+    auto_remove: true
+    detach: false
+    # image seemed to work fine with both rocky8 and rocky9. usually rocky8/rhel8 will be used.
+    image: registry.access.redhat.com/ubi8/openjdk-17:1.16-1.1687182768
+    volumes:
+      - "{{ role_path }}/../../../:/app"
+    working_dir: /app
+    command: >-
+      mvn clean install
+        -Dmaven.test.skip=true
+        -Dmaven.repo.local=/app/provisioning/roles/offline-download/files/offline-files/maven-deps
+
+- name: Create zip of maven dependencies
+  archive:
+    path: "{{ role_path }}/files/offline-files/maven-deps/*"
+    dest: "{{ role_path }}/files/offline-files/maven-deps.zip"
+    format: zip
+
+# - name: Remove maven dependencies directory
+#   file:
+#     path: "{{ role_path }}/files/offline-files/maven-deps"
+#     state: absent
+
+- name: Download Version {{ nifi_version }} of NiFi
+  get_url:
+    url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-{{ nifi_version }}-bin.zip"
+    dest: "{{ role_path }}/files/offline-files/nifi-{{ nifi_version }}-bin.zip"
+    mode: 0755
+
+- name: Download NiFi Tools
+  get_url:
+    url: "https://archive.apache.org/dist/nifi/{{ nifi_version }}/nifi-toolkit-{{ nifi_version }}-bin.zip"
+    dest: "{{ role_path }}/files/offline-files/nifi-toolkit-{{ nifi_version }}-bin.zip"
+    mode: 0755
+
+- name: Download Version {{ mariadb_client_version }} of mariadb client
+  get_url:
+    url: "https://dlm.mariadb.com/2912798/Connectors/java/connector-java-{{ mariadb_client_version }}/mariadb-java-client-{{ mariadb_client_version }}.jar"
+    dest: "{{ role_path }}/files/offline-files/mariadb-java-client-{{ mariadb_client_version }}.jar"
+
+# - name: Create zip of offline-files
+#   archive:
+#     path: "{{ role_path }}/files/offline-files"
+#     dest: "{{ role_path }}/files/offline-files.zip"
+#     format: zip


### PR DESCRIPTION
Add support for offline deployment

- Create ansible role to download all necessary files from the internet into a single folder.
- Update configuration to allow offline deployments using the location of the offline-files directory.