### PR TITLE
Update offline-download role for terraform and packer

### DIFF
--- a/provisioning/group_vars/all.yml
+++ b/provisioning/group_vars/all.yml
@@ -2,7 +2,7 @@
 nifi:
   username: "{{ lookup('env', 'NIFI_USERNAME') | default('', True) }}"
   password: "{{ lookup('env', 'NIFI_PASSWORD') | default('', True) }}"
-  version: "{{ lookup('env', 'NIFI_VERSION') | default('1.23.0', True) }}"
+  version: "{{ lookup('env', 'NIFI_VERSION') | default('1.23.2', True) }}"
 
 mariadb_client_version: "{{ lookup('env', 'MARIADB_CLIENT_VERSION') | default('3.1.4', True) }}"
 is_macos: "{{ lookup('env', 'IS_MACOS') | default(false, True) | bool }}"

--- a/provisioning/roles/offline-download/defaults/main.yml
+++ b/provisioning/roles/offline-download/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+proxy_protocol: "{{ lookup('env', 'PROXY_PROTOCOL') | default('http', True) }}"
+proxy_host: "{{ lookup('env', 'PROXY_HOST') | default('', True) }}"
+proxy_port: "{{ lookup('env', 'PROXY_PORT') | default('', True) }}"
+
+mvn_proxy_args: >-
+  {{
+    ''
+    if proxy_host == '' and proxy_port == ''
+    else '-Dhttp.proxyHost='~proxy_host~' -Dhttp.proxyPort='~proxy_port~' -Dhttps.proxyHost='~proxy_host~' -Dhttps.proxyPort='~proxy_port
+  }}
+
+pip_proxy_args: >-
+  {{
+    ''
+    if proxy_host == '' and proxy_port == ''
+    else '--proxy '~proxy_protocol~'://'~proxy_host~':'~proxy_port
+  }}

--- a/provisioning/roles/offline-download/files/.gitignore
+++ b/provisioning/roles/offline-download/files/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!plugins.pkr.hcl
+!terraform-bundle.hcl

--- a/provisioning/roles/offline-download/files/plugins.pkr.hcl
+++ b/provisioning/roles/offline-download/files/plugins.pkr.hcl
@@ -1,0 +1,17 @@
+packer {
+  required_version = ">= 1.7.0"
+  required_plugins {
+    vsphere = {
+      version = ">= 1.0.3"
+      source  = "github.com/hashicorp/vsphere"
+    }
+    qemu = {
+      version = ">= 1.0.8"
+      source  = "github.com/hashicorp/qemu"
+    }
+    ansible = {
+      version = ">= 1.0.0"
+      source  = "github.com/hashicorp/ansible"
+    }
+  }
+}

--- a/provisioning/roles/offline-download/files/terraform-bundle.hcl
+++ b/provisioning/roles/offline-download/files/terraform-bundle.hcl
@@ -1,0 +1,20 @@
+terraform {
+  version = "1.5.5"
+}
+
+providers {
+  vsphere = {
+    source   = "hashicorp/vsphere"
+    versions = [">= 2.1.0"]
+  }
+
+  local = {
+    source   = "hashicorp/local"
+    versions = [">= 2.2.2"]
+  }
+  
+  libvirt = {
+    source   = "dmacvicar/libvirt"
+    versions = ["0.6.14"]
+  }
+}

--- a/provisioning/roles/offline-download/tasks/main.yml
+++ b/provisioning/roles/offline-download/tasks/main.yml
@@ -5,46 +5,23 @@
     state: directory
     mode: 0755
 
-# Using docker is better because then the dependencies downloaded are using a matching OS (RHEL/ROCKY 8/9).
-# Use clean install instead of "dependency:go-offline" as "dependency:go-offline" doesn't get everything.
-- name: Download maven dependencies using docker
-  docker_container:
-    name: noe_setup_maven_deps_download
-    auto_remove: true
-    detach: false
-    # image seemed to work fine with both rocky8 and rocky9. usually rocky8/rhel8 will be used.
-    image: registry.access.redhat.com/ubi8/openjdk-17:1.16-1.1687182768
-    volumes:
-      - "{{ role_path }}/../../../:/app"
-    working_dir: /app
-    command: >-
-      mvn clean install
-        -Dmaven.test.skip=true
-        -Dmaven.repo.local=/app/provisioning/roles/offline-download/files/offline-files/maven-deps
-
-- name: Create zip of maven dependencies
-  archive:
-    path: "{{ role_path }}/files/offline-files/maven-deps/*"
-    dest: "{{ role_path }}/files/offline-files/maven-deps.zip"
-    format: zip
+- name: Create bin folder
+  file:
+    path: "{{ role_path }}/files/offline-files/bin"
+    state: directory
     mode: 0755
 
-# - name: Remove maven dependencies directory
-#   file:
-#     path: "{{ role_path }}/files/offline-files/maven-deps"
-#     state: absent
-
-- name: Download NiFi Version {{ nifi.version }}
-  get_url:
-    url: "https://archive.apache.org/dist/nifi/{{ nifi.version }}/nifi-{{ nifi.version }}-bin.zip"
-    dest: "{{ role_path }}/files/offline-files/nifi-{{ nifi.version }}-bin.zip"
+- name: Create pip-packages folder
+  file:
+    path: "{{ role_path }}/files/offline-files/pip-packages"
+    state: directory
     mode: 0755
 
-- name: Download NiFi Tools
-  get_url:
-    url: "https://archive.apache.org/dist/nifi/{{ nifi.version }}/nifi-toolkit-{{ nifi.version }}-bin.zip"
-    dest: "{{ role_path }}/files/offline-files/nifi-toolkit-{{ nifi.version }}-bin.zip"
-    mode: 0755
+- name: Download maven files
+  import_tasks: "./mvn.yml"
+
+- name: Download NiFi files
+  import_tasks: "./nifi.yml"
 
 - name: Download Version mariadb client {{ mariadb_client_version }}
   get_url:
@@ -52,8 +29,18 @@
     dest: "{{ role_path }}/files/offline-files/mariadb-java-client-{{ mariadb_client_version }}.jar"
     mode: 0755
 
-# - name: Create zip of offline-files
-#   archive:
-#     path: "{{ role_path }}/files/offline-files"
-#     dest: "{{ role_path }}/files/offline-files.zip"
-#     format: zip
+- name: Download terraform binary and providers
+  import_tasks: "./terraform.yml"
+
+- name: Download packer binary and plugins
+  import_tasks: "./packer.yml"
+
+- name: Download python pip packages
+  import_tasks: "./pip.yml"
+
+- name: Create zip of offline-files
+  archive:
+    path: "{{ role_path }}/files/offline-files"
+    dest: "{{ role_path }}/files/offline-files-{{ ansible_date_time.date }}.zip"
+    format: zip
+    mode: 0755

--- a/provisioning/roles/offline-download/tasks/mvn.yml
+++ b/provisioning/roles/offline-download/tasks/mvn.yml
@@ -1,0 +1,29 @@
+---
+# Using docker is better because then the dependencies downloaded are using a matching OS (RHEL/ROCKY 8/9).
+# Use clean install instead of "dependency:go-offline" as "dependency:go-offline" doesn't get everything.
+- name: Download maven dependencies using docker
+  docker_container:
+    name: noe_setup_maven_deps_download
+    auto_remove: true
+    detach: false
+    # image seemed to work fine with both rocky8 and rocky9. usually rocky8/rhel8 will be used.
+    image: registry.access.redhat.com/ubi8/openjdk-17:1.16-1.1687182768
+    volumes:
+      - "{{ role_path }}/../../../:/app"
+    working_dir: /app
+    command: >-
+      mvn clean install {{ mvn_proxy_args }}
+        -Dmaven.test.skip=true
+        -Dmaven.repo.local=/app/provisioning/roles/offline-download/files/offline-files/maven-deps
+
+- name: Create zip of maven dependencies
+  archive:
+    path: "{{ role_path }}/files/offline-files/maven-deps/*"
+    dest: "{{ role_path }}/files/offline-files/maven-deps.zip"
+    format: zip
+    mode: 0755
+
+- name: Remove maven dependencies directory
+  file:
+    path: "{{ role_path }}/files/offline-files/maven-deps"
+    state: absent

--- a/provisioning/roles/offline-download/tasks/nifi.yml
+++ b/provisioning/roles/offline-download/tasks/nifi.yml
@@ -1,0 +1,18 @@
+---
+- name: Download NiFi Version {{ nifi.version }}
+  get_url:
+    url: "https://archive.apache.org/dist/nifi/{{ nifi.version }}/nifi-{{ nifi.version }}-bin.zip"
+    dest: "{{ role_path }}/files/offline-files/nifi-{{ nifi.version }}-bin.zip"
+    mode: 0755
+  environment:
+    http_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+    https_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+
+- name: Download NiFi Tools
+  get_url:
+    url: "https://archive.apache.org/dist/nifi/{{ nifi.version }}/nifi-toolkit-{{ nifi.version }}-bin.zip"
+    dest: "{{ role_path }}/files/offline-files/nifi-toolkit-{{ nifi.version }}-bin.zip"
+    mode: 0755
+  environment:
+    http_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+    https_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"

--- a/provisioning/roles/offline-download/tasks/packer.yml
+++ b/provisioning/roles/offline-download/tasks/packer.yml
@@ -1,0 +1,25 @@
+---
+- name: Download packer binary
+  unarchive:
+    src: "https://releases.hashicorp.com/packer/1.9.4/packer_1.9.4_linux_amd64.zip"
+    dest: "{{ role_path }}/files/offline-files/bin"
+    remote_src: true
+
+- name: Download packer plugins using docker
+  docker_container:
+    name: noe_setup_packer_plugins_download
+    auto_remove: true
+    detach: false
+    image: hashicorp/packer:1.8.4
+    volumes:
+      - "{{ role_path }}/../../../:/app"
+    working_dir: /app
+    entrypoint: []
+    env:
+      http_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+      https_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+    command: |
+      /bin/sh -c 'apk --no-cache add zip && \
+        packer init /app/provisioning/roles/offline-download/files/plugins.pkr.hcl && \
+        cd /root/.config/packer && \
+        zip -r /app/provisioning/roles/offline-download/files/offline-files/packer-plugins.zip .'

--- a/provisioning/roles/offline-download/tasks/pip.yml
+++ b/provisioning/roles/offline-download/tasks/pip.yml
@@ -1,0 +1,26 @@
+---
+- name: Download pip dependencies using docker
+  docker_container:
+    name: noe_setup_pip_packages_download
+    auto_remove: true
+    detach: false
+    image: python:3.6.8
+    volumes:
+      - "{{ role_path }}/../../../:/app"
+    working_dir: /app
+    command: >-
+      pip download {{ pip_proxy_args }}
+        --dest /app/provisioning/roles/offline-download/files/offline-files/pip-packages/
+        ansible flake8 black
+
+- name: Create zip of python pip packages
+  archive:
+    path: "{{ role_path }}/files/offline-files/pip-packages/*"
+    dest: "{{ role_path }}/files/offline-files/pip-packages.zip"
+    format: zip
+    mode: 0755
+
+- name: Remove python pip packages directory
+  file:
+    path: "{{ role_path }}/files/offline-files/pip-packages"
+    state: absent

--- a/provisioning/roles/offline-download/tasks/terraform.yml
+++ b/provisioning/roles/offline-download/tasks/terraform.yml
@@ -1,0 +1,29 @@
+---
+- name: Download terraform binary
+  unarchive:
+    src: "https://releases.hashicorp.com/terraform/1.5.5/terraform_1.5.5_linux_amd64.zip"
+    dest: "{{ role_path }}/files/offline-files/bin"
+    remote_src: true
+
+- name: Download terraform providers using docker
+  docker_container:
+    name: noe_setup_terraform_providers_download
+    auto_remove: true
+    detach: false
+    image: golang:alpine
+    volumes:
+      - "{{ role_path }}/../../../:/app"
+    working_dir: /app
+    env:
+      http_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+      https_proxy: "{{ '' if proxy_host == '' or proxy_port == '' else proxy_protocol~'://'~proxy_host~':'~proxy_port }}"
+    command: |
+      /bin/sh -c 'apk --no-cache add git unzip && \
+        git clone --single-branch --branch=v0.15 --depth=1 https://github.com/hashicorp/terraform.git terraform_repo && \
+        cd terraform_repo && \
+        go build -o ../terraform-bundle ./tools/terraform-bundle && \
+        cd ../ && \
+        rm -rf terraform_repo && \
+        ./terraform-bundle package -os=linux -arch=amd64 /app/provisioning/roles/offline-download/files/terraform-bundle.hcl && \
+        mv terraform_* /app/provisioning/roles/offline-download/files/offline-files/terraform-providers.zip && \
+        rm -rf terraform-bundle terraform_repo'

--- a/terraform/qemu/providers.tf
+++ b/terraform/qemu/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "~> 1.4.2"
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"

--- a/terraform/vsphere/providers.tf
+++ b/terraform/vsphere/providers.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = "~> 1.4.2"
   required_providers {
     vsphere = {
       version = "~> 2.1.0"


### PR DESCRIPTION
Update offline-download role for terraform and packer

- Updated the offline-download role to have different tasks for each component we need to download.
- The offline-download role now downloads the terraform binary and its providers in a zip.
- The offline-download role now downloads the packer binary and its plugins into a zip.
- Add support for offline-downloading behind a proxy.